### PR TITLE
Fix: Show multiple matches for tag autocomplete

### DIFF
--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -3,6 +3,7 @@ use crate::error::{CleanboxError, Result};
 use crate::filesystem::FileManager;
 use crate::tags::{TagDictionary, TagResolution, TagResolutionFlow};
 use rustyline::completion::{Completer, Pair};
+use rustyline::config::{CompletionType, Config};
 use rustyline::highlight::Highlighter;
 use rustyline::hint::Hinter;
 use rustyline::validate::Validator;
@@ -392,7 +393,10 @@ impl<P: UserPrompt> SmartTagSelector<P> {
         loop {
             // Create editor with fuzzy completer fresh each time to avoid borrowing issues
             let completer = FuzzyTagCompleter::new(self.flow.dictionary());
-            let mut editor = Editor::new().map_err(|e| {
+            let config = Config::builder()
+                .completion_type(CompletionType::List)
+                .build();
+            let mut editor = Editor::with_config(config).map_err(|e| {
                 CleanboxError::InvalidUserInput(format!("Failed to initialize editor: {e}"))
             })?;
             editor.set_helper(Some(completer));


### PR DESCRIPTION
## Summary
- Configure rustyline editor to use `CompletionType::List` instead of default circular behavior
- Display all matching tags when user presses TAB for autocomplete
- Allow users to see available options instead of cycling through them invisibly

## Problem
Previously, when typing a partial tag and pressing TAB, users could only cycle through matches without seeing what options were available. This made the autocomplete feature difficult to use effectively.

## Solution
- Added import for rustyline's `Config` and `CompletionType`
- Modified `SmartTagSelector::prompt_tags()` to create an editor with `CompletionType::List` configuration
- This leverages rustyline's built-in capability to display multiple completion matches visually

## Test plan
- [x] Code compiles successfully (`cargo check`)
- [x] All existing tests pass (`cargo test`)
- [x] Code formatting is correct (`cargo fmt`)
- [x] No clippy warnings (`cargo clippy`)
- [x] Manual testing: Run the application and verify that TAB completion shows multiple matches

Resolves #9

🤖 Generated with [Claude Code](https://claude.ai/code)